### PR TITLE
driver: infineon: Fix the conditional judgment in wl_android.c

### DIFF
--- a/drivers/infineon/wl_android.c
+++ b/drivers/infineon/wl_android.c
@@ -8978,8 +8978,7 @@ wl_handle_private_cmd(struct net_device *net, char *command, u32 cmd_len)
 #endif /* DHD_BLOB_EXISTENCE_CHECK */
 		if ((rev_info_delim) &&
 			(strnicmp(rev_info_delim, CMD_COUNTRY_DELIMITER,
-			strlen(CMD_COUNTRY_DELIMITER)) == 0) &&
-			(rev_info_delim + 1)) {
+			strlen(CMD_COUNTRY_DELIMITER)) == 0)) {
 			revinfo  = bcm_atoi(rev_info_delim + 1);
 		}
 #ifdef SAVE_CONNECTION_WHEN_CC_UPDATE


### PR DESCRIPTION
修复 wl_android.c中的判断。
目前的代码编译会报错：
```c
 error: the comparison will always evaluate as ‘true’ for the pointer operand in ‘rev_info_delim + 1’ must not be NULL [-Werror=address]
```
参考bcmdhd中的 wl_android.c 代码进行修改。